### PR TITLE
Remove useless venv activation

### DIFF
--- a/nuxeoenv.sh
+++ b/nuxeoenv.sh
@@ -296,6 +296,5 @@ get_opts "$@"
 get_input
 parse_input
 venv_init
-venv_activate
 generate_compose
 bye


### PR DESCRIPTION
Whenever we run the nuxeoenv in Mac, we do not need to create a virtualenv because ansible is already install, also the virtual env activation is already done during the env_init.