### PR TITLE
Version comparison elastic conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 instance.clid
 *.iml
 *.retry
+.idea

--- a/group_vars/all/nuxeo-10.10.yml
+++ b/group_vars/all/nuxeo-10.10.yml
@@ -1,5 +1,5 @@
 ---
-nuxeo_version: 10.10
+nuxeo_version: "10.10"
 nuxeo_image: "nuxeo:10.10"
 elastic_image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.3"
 elastic5: false

--- a/group_vars/all/nuxeo-7.10.yml
+++ b/group_vars/all/nuxeo-7.10.yml
@@ -1,5 +1,5 @@
 ---
-nuxeo_version: 7.10
+nuxeo_version: "7.10"
 nuxeo_image: "nuxeo:7.10"
 elastic_image: "elasticsearch:1.7.6"
 elastic5: true

--- a/group_vars/all/nuxeo-8.10.yml
+++ b/group_vars/all/nuxeo-8.10.yml
@@ -1,5 +1,5 @@
 ---
-nuxeo_version: 8.10
+nuxeo_version: "8.10"
 nuxeo_image: "nuxeo:8.10"
 elastic_image: "elasticsearch:2.3.5"
 elastic5: true

--- a/group_vars/all/nuxeo-9.10.yml
+++ b/group_vars/all/nuxeo-9.10.yml
@@ -1,5 +1,5 @@
 ---
-nuxeo_version: 9.10
+nuxeo_version: "9.10"
 nuxeo_image: "nuxeo:9.10"
 elastic_image: "docker.elastic.co/elasticsearch/elasticsearch:5.6.3"
 elastic5: true

--- a/group_vars/all/nuxeo-latest.yml
+++ b/group_vars/all/nuxeo-latest.yml
@@ -1,5 +1,5 @@
 ---
-nuxeo_version: 11.1
+nuxeo_version: "11.1"
 nuxeo_image: "nuxeo:latest"
 elastic_image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.3"
 elastic5: false

--- a/nuxeoenv.sh
+++ b/nuxeoenv.sh
@@ -296,6 +296,5 @@ get_opts "$@"
 get_input
 parse_input
 venv_init
-venv_activate
 generate_compose
 bye

--- a/roles/common/templates/docker-compose.yml.j2
+++ b/roles/common/templates/docker-compose.yml.j2
@@ -212,6 +212,7 @@ services:
     volumes:
       - ./nuxeo/{{ nuxeo_node }}.conf:/docker-entrypoint-initnuxeo.d/nuxeo.conf:ro
       - ./nuxeo/init-nuxeo.sh:/docker-entrypoint-initnuxeo.d/init-nuxeo.sh:ro
+      - ./nuxeo/docker-entrypoint-initnuxeo.d:/docker-entrypoint-initnuxeo.d:rw
       - {{ root_path }}/data/nuxeo-binaries:/var/lib/nuxeo/binaries:rw
       - {{ root_path }}/data/{{ nuxeo_node }}/data:/var/lib/nuxeo/data:rw
       - {{ root_path }}/data/{{ nuxeo_node }}/packages:/opt/nuxeo/server/packages:rw
@@ -226,7 +227,7 @@ services:
 {% endfor %}
 {% if stream and kafka %}
   stream:
-    image: nuxeo:{{ nuxeo_version }}
+    image: {{ nuxeo_image }}
     container_name: stream
     hostname: stream
     depends_on:

--- a/roles/common/templates/nuxeo.conf.j2
+++ b/roles/common/templates/nuxeo.conf.j2
@@ -53,21 +53,29 @@ nuxeo.redis.host=redis
 {% if not swm %}
 nuxeo.work.queuing=redis
 {% endif %}
+{% else %}
+nuxeo.redis.enabled=false
 {% endif %}
-{% if nuxeo_version is version_compare('9.10', '<=') %}
+{% if nuxeo_version is version_compare('9.10', '<') %}
 elasticsearch.client=TransportClient
 elasticsearch.clusterName=docker-cluster
+{% if elastic %}
+elasticsearch.indexNumberOfReplicas=0
+elasticsearch.indexNumberOfShards=1
+#elasticsearch.addressList=elasticsearch:9300
+{% endif %}
 {% else %}
 elasticsearch.client=RestClient
-{% endif %}
 {% if elastic %}
 elasticsearch.indexNumberOfReplicas=0
 elasticsearch.indexNumberOfShards=1
 elasticsearch.addressList=http://elasticsearch:9200
 elasticsearch.httpReadOnly.baseUrl=http://elasticsearch:9200
 {% endif %}
+{% endif %}
 {% if swm %}
 nuxeo.stream.work.enabled=true
+nuxeo.pubsub.provider=stream
 {% endif %}
 {% if prometheus or jaeger or zipkin %}
 opencensus.enabled=true


### PR DESCRIPTION
Wrong version comparison operator + elastic config for 9.10

* Change the version comparator values otherwise 9.10 in the yml is set as 9.1 and some config are wrong
* Defferenciate 9.10 Elastic configuration (RestClient and TransportClient)
* Add the mapping to the docker-entrypoint-initnuxeo.d so whenever we drop a package in nuxeo/docker-entrypoint-initnuxeo.d/ they get installed automatically