### PR TITLE
Fix installation command for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Of course the first time you use nuxeo stacks it will take longer because you ha
 
   - On Ubuntu:
   ```bash
-  sudo apt install python3-pip jq
-  pip3 install virtualenv
+  sudo apt install python3-pip jq python3-virtualenv
   ```
   Note that on Ubuntu, the first time `nuxeoenv.sh` is run it will install `ansible` locally.
 


### PR DESCRIPTION
Tested under Ubuntu 20.04
Using the pip3 command leads to an error saying the virtualenv command doesn't exist.
Installing using apt + having used the pip3 command leads to a ModuleNotFoundError
=> suggesting to use the apt command only