### PR TITLE
nuxeo.templates malformation issue

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -9,19 +9,19 @@
   pre_tasks:
     - name: Mongo template
       set_fact:
-        nuxeo_templates: "{{ nuxeo_templates }} + ['mongodb']"
+        nuxeo_templates: "{{ nuxeo_templates  + ['mongodb']}}"
       when: "mongo"
     - name: PostgreSQL template
       set_fact:
-        nuxeo_templates: "{{ nuxeo_templates }} + ['postgresql']"
+        nuxeo_templates: "{{ nuxeo_templates  + ['postgresql']}}"
       when: "postgres"
     - name: Redis template
       set_fact:
-        nuxeo_templates: "{{ nuxeo_templates }} + ['redis']"
+        nuxeo_templates: "{{ nuxeo_templates  + ['redis']}}"
       when: "redis and (nuxeo_version is version_compare('9.10', '>'))"
     - name: Kafka Confluent template
       set_fact:
-        nuxeo_templates: "{{ nuxeo_templates }} + ['/templates/confluent']"
+        nuxeo_templates: "{{ nuxeo_templates  + ['/templates/confluent']}}"
       when: "kafkaconfluent"
     - name: Nuxeo standalone
       set_fact:


### PR DESCRIPTION
Currently, the value of nuxeo.templates key is getting generated in nuxeo.conf as: **[,',d,e,f,a,u,l,t,',], ,+, ,[,',m,o,n,g,o,d,b,',]** instead of **default,mongodb**

Attempting to fix the same.